### PR TITLE
fixando erros de gramáticas e markdown

### DIFF
--- a/Instruções-simples/return.md
+++ b/Instruções-simples/return.md
@@ -1,61 +1,48 @@
 ## Instrução return
 
 
-- O __return__ é usado no final de uma função para sinalizar o fim da mesma e retornar um valor;
-- Após a declara dessa instrução de retorno, as ações dentro daquela função não são mais executadas até que sejam chamadas novamente;
-- Se a instrução __return__ estiver sem nenhuma expressão, será retornado *None*.
+- O **return** é utilizado em funções para sinalizar que a função obeteve um resultado e este deve ser retornado;
+- Após a declaração dessa instrução, outras instruções não serão executadas até que a função seja chamada novamente;
+- Se a instrução **return** estiver sem nenhuma expressão, será retornado `None`.
+    * Caso a instrução não seja declarada, o retorno será `None`.
 
 
 ## Sintaxe
 
 ```python
-
-    def sintaxe_example():
-        statements
-        .
-        .
-        return [expression]
+def function_name():
+    statements
+    .
+    .
+    return [expression]
 ```
 
 ## Exemplos
 
-Vamos fazer uma soma de dois numeros e usar a instrução __return__ para nos mostrar o valor da operação:
+Vamos fazer uma soma de dois numeros e usar o **return** para nos mostrar o valor da operação
 
 ```python
-In[]:
-
-    def add(a, b): 
-
-        # retornando a soma a + b  
-        return a + b 
-
-res = add(2, 3) 
-print("O resultado da operação é: {}".format(res)) 
+>>> def add(a, b): 
+...    """Essa função junta `a` com `b` e retorna o resultado.""
+...    return a + b 
+...
+>>>
+>>> resultado = add(2, 3) 
+>>> print("O resultado da operação é:", res)
+O resultado da operação é: 5
 ```
 
+Vamos ver o que a função retorna se não colocarmos o **return**.
 ```python
-Out[]:
-
-    O resultado da operação é: 5
+>>> def algo():
+...     pass
+...
+>>> resultado = algo()
+>>> resultado
+None
 ```
+Eita, mas eu não utilizei o **return**, por que ele retornou `None`?
+Todas as funções em Python retornam alguma coisa quando executadas, por padrão, esse retorno é `None`.
+Ou seja, a nossa função não retorna nada, literalmente!
 
-E se quisermos tivermos uma função de retorno booleano (true/false), podemos utilizar o __return__ da seguinte forma:
-
-```python
-In[]:
-
-    def is_true(a): 
-  
-        # retornando um valor booleano (true/false) 
-        return bool(a) 
-
-res = is_true(2<5) 
-print("\nO resultado dessa função é: {}".format(res))
-```
-
-```python
-Out[]:
-
-   O resultado dessa função é: True
-```
-
+Faça o teste, tente guardar o retorno da função `print` e veja o que acontece!


### PR DESCRIPTION
Removi o exemplo em que utiliza `return bool(parameter)` porque a expressão já é resolvida e não há necessidade de "resolve-lá" novamente.
Arrumei alguns erros de gramáticas e adicionei um complemente que acredito ser necessário, o retorno padrão de cada função.