### PR TITLE
Alteração nas URLs de instalação para MacOS e Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 ### 2. Instalação
 
 [Windows](/Instalação/Windows.md)<br>
-[Linux](/Introdução/Linux.md)<br>
-[MacOS](/Introdução/MacOS.md)
+[Linux](/Instalação/Linux.md)<br>
+[MacOS](/Instalação/MacOS.md)
 
 ### 3. Estrutura de dados em python
 


### PR DESCRIPTION
As URLS para instalação do Python no MacOS e no Linux estavam levando para a pasta Introdução, troquei para Instalação, como já estava a URL da instalação para Windows.